### PR TITLE
Use lsns' human-readable output instead of JSON

### DIFF
--- a/cnetstat.go
+++ b/cnetstat.go
@@ -202,7 +202,7 @@ func cnetstat() error {
 	// connections has one slice of Connections for each namespace
 	var connections = make([][]Connection, len(namespaces))
 	for i, namespace := range namespaces {
-		conns, err := getConnectionsFromNamespace(namespace.Pid)
+		conns, err := getConnectionsFromNamespace(strconv.Itoa(namespace.Pid))
 		if err != nil {
 			return err
 		}
@@ -226,6 +226,7 @@ func cnetstat() error {
 	}
 
 	kubeConnections := getKubeConnections(allConnections, pidMap)
+	println("Got", len(kubeConnections), "kubeConnections")
 
 	switch format {
 	case "json":

--- a/lsns.go
+++ b/lsns.go
@@ -1,29 +1,55 @@
 package main
 
 import (
+	"bufio"
 	"context"
-	"encoding/json"
+	"fmt"
 	"os/exec"
+	"strings"
 )
 
 type NamespaceData struct {
-	Ns      string
-	Pid     string
-	Command string
+	Ns  int
+	Pid int
 }
 
-// Parse output from 'lsns --json --output ns,pid,command'
-func parseLsnsOutput(blob []byte) ([]NamespaceData, error) {
-	var dummy map[string][]NamespaceData
+var expectedHeaders = []string{
+	"NS", "PID",
+}
 
-	err := json.Unmarshal(blob, &dummy)
-	if err != nil {
-		return nil, err
+// Parse output from 'lsns --output ns,pid'
+func parseLsnsOutput(blob []byte) ([]NamespaceData, error) {
+	// Note: lsns has a --json option, so you would think that we
+	// would use that, pass the result to Go's builtin JSON
+	// decoder, and not have to write a custom parser. Except
+	// that, somewhere between util-linux 2.31 and 2.34, the JSON
+	// output format changed. The old version prints ns and pid as
+	// JSON strings containing ints, and the new one prints them
+	// as JSON numbers. The non-JSON output format is the same,
+	// which makes it easier to support both versions this way.
+	lines := bufio.NewScanner(strings.NewReader(string(blob)))
+	var result []NamespaceData
+
+	lines.Scan()
+	header := lines.Text()
+	if !stringSlicesEqual(strings.Fields(header), expectedHeaders) {
+		return nil, fmt.Errorf("Unexpected header of lsns output: %s", header)
 	}
 
-	// The map should always contain a single element, with key
-	// "namespaces"
-	return dummy["namespaces"], nil
+	for lines.Scan() {
+		var ns, pid int
+		_, err := fmt.Sscanf(lines.Text(), "%d %d", &ns, &pid)
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, NamespaceData{
+			Ns:  ns,
+			Pid: pid,
+		})
+	}
+
+	return result, nil
 }
 
 // Run lsns and parse the output.
@@ -32,7 +58,7 @@ func parseLsnsOutput(blob []byte) ([]NamespaceData, error) {
 func listNetNamespaces() ([]NamespaceData, error) {
 	ctx, _ := context.WithTimeout(context.Background(), subprocessTimeout)
 
-	output, err := exec.CommandContext(ctx, "lsns", "--json", "--type", "net", "--output", "ns,pid,command").Output()
+	output, err := exec.CommandContext(ctx, "lsns", "--type", "net", "--output", "ns,pid").Output()
 	if err != nil {
 		return nil, err
 	}

--- a/lsns_test.go
+++ b/lsns_test.go
@@ -4,22 +4,18 @@ import (
 	"testing"
 )
 
-// This matches the format of 'sudo lsns --json --type net --output ns,pid,command'
+// This matches the format of 'sudo lsns --type net --output ns,pid'
 
-var lsnsOutput = []byte(`
-{
-   "namespaces": [
-      {"ns": "23", "pid": "1", "command": "/sbin/init"},
-      {"ns": "24", "pid": "96", "command": "/pause"},
-      {"ns": "25", "pid": "284", "command": "/pause"}
-   ]
-}
+var lsnsOutput = []byte(`  NS   PID
+2342     1
+9694   893
+8766  3929
 `)
 
 var lsnsCorrectParse = []NamespaceData{
-	NamespaceData{Ns: "23", Pid: "1", Command: "/sbin/init"},
-	NamespaceData{Ns: "24", Pid: "96", Command: "/pause"},
-	NamespaceData{Ns: "25", Pid: "284", Command: "/pause"},
+	NamespaceData{Ns: 2342, Pid: 1},
+	NamespaceData{Ns: 9694, Pid: 893},
+	NamespaceData{Ns: 8766, Pid: 3929},
 }
 
 func TestParseLsnsOutput(t *testing.T) {

--- a/netstat.go
+++ b/netstat.go
@@ -36,21 +36,6 @@ func hostAndPort(address string) (string, string, error) {
 	return address[:split], address[split+1:], nil
 }
 
-func stringSlicesEqual(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	for i, a_elt := range a {
-		b_elt := b[i]
-		if a_elt != b_elt {
-			return false
-		}
-	}
-
-	return true
-}
-
 // Parse the output of 'sudo netstat --tcp --program'
 var expectedHeaderFields = []string{
 	"Proto", "Recv-Q", "Send-Q", "Local", "Address", "Foreign",

--- a/util.go
+++ b/util.go
@@ -1,0 +1,16 @@
+package main
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i, a_elt := range a {
+		b_elt := b[i]
+		if a_elt != b_elt {
+			return false
+		}
+	}
+
+	return true
+}


### PR DESCRIPTION
lsns' JSON output format changed between util-linux 2.31 and 2.34, but
its human-readable output format is the same, which means not-JSON is
the more reliable way to parse the output.