### PR TITLE
Add summary statistics

### DIFF
--- a/cnetstat.go
+++ b/cnetstat.go
@@ -98,14 +98,14 @@ func getKubeConnections(connections []Connection, pidMap map[int]ContainerPath) 
 
 // Like the TCP 4-tuple, but with a ContainerPath for the local side
 type KubeConnectionId struct {
-	container ContainerPath
+	container  ContainerPath
 	remoteHost string
 	remotePort string
 }
 
 type ConnectionCount struct {
 	connId KubeConnectionId
-	count int
+	count  int
 }
 
 func summarizeKubeConnections(connections []KubeConnection) []ConnectionCount {
@@ -113,8 +113,8 @@ func summarizeKubeConnections(connections []KubeConnection) []ConnectionCount {
 
 	for _, conn := range connections {
 		connId := KubeConnectionId{container: conn.container,
-				remoteHost: conn.conn.remoteHost,
-				remotePort: conn.conn.remotePort}
+			remoteHost: conn.conn.remoteHost,
+			remotePort: conn.conn.remotePort}
 		count, ok := stats[connId]
 
 		if ok {
@@ -170,7 +170,7 @@ func (kc KubeConnection) Fields() []string {
 }
 
 type CnetstatConfig struct {
-	outputFormat string  // Either "table" or "json"
+	outputFormat string // Either "table" or "json"
 	summaryStats bool
 }
 
@@ -255,7 +255,7 @@ func cnetstat() error {
 
 	var table []Fielder
 	var columns []string
-	if (config.summaryStats) {
+	if config.summaryStats {
 		stats := summarizeKubeConnections(kubeConnections)
 		table = make([]Fielder, len(stats))
 		for i, _ := range stats {

--- a/cnetstat.go
+++ b/cnetstat.go
@@ -169,12 +169,13 @@ func (kc KubeConnection) Fields() []string {
 	}
 }
 
+// CnetstatConfig holds our command-line arguments
 type CnetstatConfig struct {
 	outputFormat string // Either "table" or "json"
 	summaryStats bool
 }
 
-// Parse our arguments. Return the value of the format argument - either "table" or "json"
+// Parse our arguments
 func parseArgs() (CnetstatConfig, error) {
 	var config CnetstatConfig
 

--- a/cnetstat_test.go
+++ b/cnetstat_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestSummarizeEmpty(t *testing.T) {
+	empty := make([]KubeConnection, 0)
+	val := summarizeKubeConnections(empty)
+
+	if len(val) != 0 {
+		t.Errorf("Expected no stats, got %v", val)
+	}
+}
+
+func TestSummarize(t *testing.T) {
+	// Two connections each to two different remote endpoints
+	conns := []Connection{
+		Connection{
+			protocol: "tcp",
+			localHost: "127.0.0.1",
+			localPort: "https",
+			remoteHost: "10.0.5.9",
+			remotePort: "5086",
+			connectionState: "ESTABLISHED",
+			pid: 42,
+		},
+		Connection{
+			protocol: "tcp",
+			localHost: "127.0.0.1",
+			localPort: "5069",
+			remoteHost: "10.0.5.9",
+			remotePort: "5086",
+			connectionState: "TIME_WAIT",
+			pid: 85,
+		},
+		Connection{
+			protocol: "tcp6",
+			localHost: "127.0.0.1",
+			localPort: "1234",
+			remoteHost: "10.0.3.4",
+			remotePort: "6230",
+			connectionState: "ESTABLISHED",
+			pid: 42,
+		},
+		Connection{
+			protocol: "tcp6",
+			localHost: "127.0.0.1",
+			localPort: "5982",
+			remoteHost: "10.0.3.4",
+			remotePort: "6230",
+			connectionState: "ESTABLISHED",
+			pid: 85,
+		},
+	}
+
+	// The first two connections are from the same container. The
+	// second two are from different containers.
+	kubeConns := []KubeConnection{
+		KubeConnection{
+			conn: conns[0],
+			container: ContainerPath{
+				PodNamespace: "myapp",
+				PodName: "frontend",
+				ContainerName: "fe-server",
+			},
+		},
+		KubeConnection{
+			conn: conns[1],
+			container: ContainerPath{
+				PodNamespace: "myapp",
+				PodName: "frontend",
+				ContainerName: "fe-server",
+			},
+		},
+		KubeConnection{
+			conn: conns[2],
+			container: ContainerPath{
+				PodNamespace: "myapp",
+				PodName: "frontend",
+				ContainerName: "fe-server",
+			},
+		},
+		KubeConnection{
+			conn: conns[3],
+			container: ContainerPath{
+				PodNamespace: "myapp",
+				PodName: "frontend",
+				ContainerName: "log-shipper",
+			},
+		},
+	}
+
+	expectedStats := []ConnectionCount{
+			ConnectionCount{
+				connId: KubeConnectionId{
+					container: ContainerPath{
+						PodNamespace: "myapp",
+						PodName: "frontend",
+						ContainerName: "fe-server",
+					},
+					remoteHost: "10.0.5.9",
+					remotePort: "5086",
+				},
+				count: 2,
+			},
+			ConnectionCount{
+				connId: KubeConnectionId{
+					container: ContainerPath{
+						PodNamespace: "myapp",
+						PodName: "frontend",
+						ContainerName: "fe-server",
+					},
+					remoteHost: "10.0.3.4",
+					remotePort: "6230",
+				},
+				count: 1,
+			},
+			ConnectionCount{
+				connId: KubeConnectionId{
+					container: ContainerPath{
+						PodNamespace: "myapp",
+						PodName: "frontend",
+						ContainerName: "log-shipper",
+					},
+					remoteHost: "10.0.3.4",
+					remotePort: "6230",
+				},
+				count: 1,
+			},
+		}
+
+	stats := summarizeKubeConnections(kubeConns)
+
+	// The order of stats is unspecified (it depends on Go's map
+	// traversal order), so we just walk the array and keep a
+	// count of how many of our expected statistics we've actually
+	// seen.
+
+	// Entries in stats that we expected to see
+	statWasExpected := make([]bool, len(stats))
+	// Entries in expectedOutput that we saw in stats
+	expectedWasSeen := make([]bool, 3)
+
+	for i, stat := range stats {
+		for j, expected := range expectedStats {
+			if stat == expected {
+				statWasExpected[i] = true
+				expectedWasSeen[j] = true
+			}
+		}
+	}
+
+	for i, expected := range statWasExpected {
+		if !expected {
+			t.Errorf("Unexpected stat: %v\n", stats[i])
+		}
+	}
+
+	for i, seen := range expectedWasSeen {
+		if !seen {
+			t.Errorf("Didn't see expected stat: %v\n", expectedStats[i])
+		}
+	}
+}

--- a/cnetstat_test.go
+++ b/cnetstat_test.go
@@ -17,40 +17,40 @@ func TestSummarize(t *testing.T) {
 	// Two connections each to two different remote endpoints
 	conns := []Connection{
 		Connection{
-			protocol: "tcp",
-			localHost: "127.0.0.1",
-			localPort: "https",
-			remoteHost: "10.0.5.9",
-			remotePort: "5086",
+			protocol:        "tcp",
+			localHost:       "127.0.0.1",
+			localPort:       "https",
+			remoteHost:      "10.0.5.9",
+			remotePort:      "5086",
 			connectionState: "ESTABLISHED",
-			pid: 42,
+			pid:             42,
 		},
 		Connection{
-			protocol: "tcp",
-			localHost: "127.0.0.1",
-			localPort: "5069",
-			remoteHost: "10.0.5.9",
-			remotePort: "5086",
+			protocol:        "tcp",
+			localHost:       "127.0.0.1",
+			localPort:       "5069",
+			remoteHost:      "10.0.5.9",
+			remotePort:      "5086",
 			connectionState: "TIME_WAIT",
-			pid: 85,
+			pid:             85,
 		},
 		Connection{
-			protocol: "tcp6",
-			localHost: "127.0.0.1",
-			localPort: "1234",
-			remoteHost: "10.0.3.4",
-			remotePort: "6230",
+			protocol:        "tcp6",
+			localHost:       "127.0.0.1",
+			localPort:       "1234",
+			remoteHost:      "10.0.3.4",
+			remotePort:      "6230",
 			connectionState: "ESTABLISHED",
-			pid: 42,
+			pid:             42,
 		},
 		Connection{
-			protocol: "tcp6",
-			localHost: "127.0.0.1",
-			localPort: "5982",
-			remoteHost: "10.0.3.4",
-			remotePort: "6230",
+			protocol:        "tcp6",
+			localHost:       "127.0.0.1",
+			localPort:       "5982",
+			remoteHost:      "10.0.3.4",
+			remotePort:      "6230",
 			connectionState: "ESTABLISHED",
-			pid: 85,
+			pid:             85,
 		},
 	}
 
@@ -60,75 +60,75 @@ func TestSummarize(t *testing.T) {
 		KubeConnection{
 			conn: conns[0],
 			container: ContainerPath{
-				PodNamespace: "myapp",
-				PodName: "frontend",
+				PodNamespace:  "myapp",
+				PodName:       "frontend",
 				ContainerName: "fe-server",
 			},
 		},
 		KubeConnection{
 			conn: conns[1],
 			container: ContainerPath{
-				PodNamespace: "myapp",
-				PodName: "frontend",
+				PodNamespace:  "myapp",
+				PodName:       "frontend",
 				ContainerName: "fe-server",
 			},
 		},
 		KubeConnection{
 			conn: conns[2],
 			container: ContainerPath{
-				PodNamespace: "myapp",
-				PodName: "frontend",
+				PodNamespace:  "myapp",
+				PodName:       "frontend",
 				ContainerName: "fe-server",
 			},
 		},
 		KubeConnection{
 			conn: conns[3],
 			container: ContainerPath{
-				PodNamespace: "myapp",
-				PodName: "frontend",
+				PodNamespace:  "myapp",
+				PodName:       "frontend",
 				ContainerName: "log-shipper",
 			},
 		},
 	}
 
 	expectedStats := []ConnectionCount{
-			ConnectionCount{
-				connId: KubeConnectionId{
-					container: ContainerPath{
-						PodNamespace: "myapp",
-						PodName: "frontend",
-						ContainerName: "fe-server",
-					},
-					remoteHost: "10.0.5.9",
-					remotePort: "5086",
+		ConnectionCount{
+			connId: KubeConnectionId{
+				container: ContainerPath{
+					PodNamespace:  "myapp",
+					PodName:       "frontend",
+					ContainerName: "fe-server",
 				},
-				count: 2,
+				remoteHost: "10.0.5.9",
+				remotePort: "5086",
 			},
-			ConnectionCount{
-				connId: KubeConnectionId{
-					container: ContainerPath{
-						PodNamespace: "myapp",
-						PodName: "frontend",
-						ContainerName: "fe-server",
-					},
-					remoteHost: "10.0.3.4",
-					remotePort: "6230",
+			count: 2,
+		},
+		ConnectionCount{
+			connId: KubeConnectionId{
+				container: ContainerPath{
+					PodNamespace:  "myapp",
+					PodName:       "frontend",
+					ContainerName: "fe-server",
 				},
-				count: 1,
+				remoteHost: "10.0.3.4",
+				remotePort: "6230",
 			},
-			ConnectionCount{
-				connId: KubeConnectionId{
-					container: ContainerPath{
-						PodNamespace: "myapp",
-						PodName: "frontend",
-						ContainerName: "log-shipper",
-					},
-					remoteHost: "10.0.3.4",
-					remotePort: "6230",
+			count: 1,
+		},
+		ConnectionCount{
+			connId: KubeConnectionId{
+				container: ContainerPath{
+					PodNamespace:  "myapp",
+					PodName:       "frontend",
+					ContainerName: "log-shipper",
 				},
-				count: 1,
+				remoteHost: "10.0.3.4",
+				remotePort: "6230",
 			},
-		}
+			count: 1,
+		},
+	}
 
 	stats := summarizeKubeConnections(kubeConns)
 


### PR DESCRIPTION
Add an option to print summary statistics instead of raw
connections. When this option is true, cnetstat will print the number
of connections between each (container, remote host, remote port)
tuple. It is on by default, because printing raw connections can
easily make the output too large to read on a machine with lots of
connections open.