### PR TITLE
Add download instructions

### DIFF
--- a/Design.md
+++ b/Design.md
@@ -52,8 +52,6 @@ host or non-Docker container systems.
 ### Add an option to run in a loop and print connections periodically
 This is required for some of the features below.
 
-### Add an option to print summary statistics instead of a connection list
-
 ### Track the owning process of TIME_WAIT connections
 When a process closes a connection, it goes into state
 `TIME_WAIT`. netstat doesn't print an associated PID any more (likely

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ If you want JSON output, try this:
 sudo ./cnetstat --format=json
 ```
 
+If you want to count connections per origin/destination pair, use the
+`--summaryStatistics` option.
+
 # Why cnetstat?
 We built cnetstat to help figure out which containers in a Kubernetes
 cluster were using up TCP ports by opening lots of short-lived

--- a/README.md
+++ b/README.md
@@ -4,9 +4,13 @@ Kubernetes container and pod names if they are from a container. It
 currently assumes that the containers run on Docker, with labels in
 the format that my version of Kubelet uses.
 
-Use it like this (from the repository root directory):
+To get an x86-64 binary, download the latest release like this:
 ```
-go build
+curl -L https://github.com/microsoft/cnetstat/releases/latest/download/cnetstat.x86_64 > cnetstat
+```
+
+and then run it like this:
+```
 sudo ./cnetstat
 ```
 
@@ -25,6 +29,10 @@ sudo ./cnetstat --format=json
 
 If you want to count connections per origin/destination pair, use the
 `--summaryStatistics` option.
+
+(To run on other architectures, you'll need to build from
+source. There are instructions in the [contributing
+doc](https://github.com/microsoft/cnetstat/blob/main/Contributing.md).
 
 # Why cnetstat?
 We built cnetstat to help figure out which containers in a Kubernetes


### PR DESCRIPTION
Add instructions to the README to download the latest cnetstat release from GitHub, instead of building from source.

This is happening now because I just created the first cnetstat release.